### PR TITLE
allow hear calls to use data.captured flag

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -292,16 +292,20 @@ class BootBot extends EventEmitter {
 
     this._hearMap.forEach(hear => {
       if (typeof hear.keyword === 'string' && hear.keyword.toLowerCase() === text.toLowerCase()) {
-        captured = true;
-        return hear.callback.apply(this, [event, new Chat(this, senderId), {
-          keyword: hear.keyword
-        }]);
-      } else if (hear.keyword instanceof RegExp && hear.keyword.test(text)) {
-        captured = true;
-        return hear.callback.apply(this, [event, new Chat(this, senderId), {
+        const res = hear.callback.apply(this, [event, new Chat(this, senderId), {
           keyword: hear.keyword,
-          match: text.match(hear.keyword)
+          captured
         }]);
+        captured = true;
+        return res;
+      } else if (hear.keyword instanceof RegExp && hear.keyword.test(text)) {
+        const res = hear.callback.apply(this, [event, new Chat(this, senderId), {
+          keyword: hear.keyword,
+          match: text.match(hear.keyword),
+          captured
+        }]);
+        captured = true;
+        return res;
       }
     });
 


### PR DESCRIPTION
This allows for the `hear` callers to determine if a message has been processed already or not. Useful for capturing all messages as a last resort easily.

For example:
```
bot.hear('hello', ...) ...
bot.hear('goodbye', ...) ...
bot.hear(/.*/, (payload, chat) => {
    // catch-all
}
```

I do realize this can be done via `bot.on('message', ...)` as well. This just makes it simpler in my use-case and I think ultimately its nicer having the symmetry between the `on` and `hear` data calls.