### PR TITLE
Add support for express middleware.

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -22,10 +22,10 @@ class BootBot extends EventEmitter {
     this.app.use(bodyParser.json({ verify: this._verifyRequestSignature.bind(this) }));
     this._hearMap = [];
     this._conversations = [];
-    this._initWebhook();
   }
 
   start(port) {
+    this._initWebhook();
     this.app.set('port', port || 3000);
     this.server = this.app.listen(this.app.get('port'), () => {
       const portNum = this.app.get('port');


### PR DESCRIPTION
As it stood before this change, express middleware couldn't be added
because it would be loaded after the route handlers.

This makes it possible for you to add middleware:

```js
'use strict';
const BootBot = require('bootbot');

// Bot

const bot = new BootBot({
  accessToken: process.env.FACEBOOK_PAGE_TOKEN,
  verifyToken: process.env.FACEBOOK_VERIFY_TOKEN,
  appSecret:   process.env.FACEBOOK_APP_SECRET,
});

bot.app.use(function(req, _res, next) {
  console.log("In middleware")

  // Mutate first message.

  let msg = req.body.entry[0].messaging[0].message
  msg.text = msg.text.toUpperCase() // OMG!!!!

  next()
})

bot.start(420)

```

The tests are passing.

This could be an possible alternative to the proposal in #3. Or at least
a temporary alternative.

Cheers!!! <3 <3 <3