### PR TITLE
Decouple message handling from express

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,24 @@ bot.hear('ask me something', (payload, chat) => {
 });
 ```
 
+- If you want to specify a custom webhook path you can add it during bot initialization:
+
+```javascript
+// when you initialize your bot
+'use strict';
+const BootBot = require('bootbot');
+
+const bot = new BootBot({
+  accessToken: 'FB_ACCESS_TOKEN',
+  verifyToken: 'FB_VERIFY_TOKEN',
+  appSecret: 'FB_APP_SECRET',
+  webhook: "/chatbots/facebook", // otherwise it will default to /webhook
+});
+```
+
 - Set up webhooks and start the express server:
 
-```
+```javascript
 bot.start();
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,21 +151,6 @@ bot.hear('ask me something', (payload, chat) => {
 });
 ```
 
-- If you want to specify a custom webhook path you can add it during bot initialization:
-
-```javascript
-// when you initialize your bot
-'use strict';
-const BootBot = require('bootbot');
-
-const bot = new BootBot({
-  accessToken: 'FB_ACCESS_TOKEN',
-  verifyToken: 'FB_VERIFY_TOKEN',
-  appSecret: 'FB_APP_SECRET',
-  webhook: "/chatbots/facebook", // otherwise it will default to /webhook
-});
-```
-
 - Set up webhooks and start the express server:
 
 ```javascript
@@ -199,9 +184,12 @@ Then use the provided HTTPS URL to config your webhook on Facebook's Dashboard. 
 | `accessToken` | string | | `Y` |
 | `verifyToken` | string | | `Y` |
 | `appSecret` | string | | `Y` |
+| `webhook` | string | `"/webhook"` | `N` |
 | `broadcastEchoes` | boolean | `false` | `N` |
 
 Creates a new `BootBot` instance. Instantiates the new express app and all required webhooks. `options` param must contain all tokens and app secret of your Facebook app. Optionally, set `broadcastEchoes` to `true` if you want the messages your bot send to be echoed back to it (you probably don't need this feature unless you have multiple bots running on the same Facebook page).
+
+If you want to specify a custom endpoint name for your webhook, you can do it with the `webhook` option.
 
 #### `.start([ port ])`
 

--- a/README.md
+++ b/README.md
@@ -698,6 +698,39 @@ If `disableInput` is set to `true`, it will disable user input in the menu. The 
 
 Removes the Persistent Menu.
 
+----------------------
+
+### Bypassing Express
+
+You may only want to use bootbot for the Facebook related config and the simple to use Send API features but handle routing from somewhere else. Or there may be times where you want to send a message out of band, like if you get a postback callback and need to end a conversation flow immediately.
+
+Or maybe you don't want to use express but a different HTTP server.
+
+#### `.handleFacebookMessage(data)`
+
+Use this to send a message from a parsed webhook message directly to your bot.
+
+```js
+const linuxNewsBot   = new BootBot({argz});
+const appleNewsBot   = new BootBot({argz});
+const windowsNewsBot = new BootBot({argz});
+
+myNonExpressRouter.get("/mywebhook", (data) => {
+	const messages = data.entry[0].messaging;
+	messages.forEach(message => {
+		switch(data.entry.id) {
+			case LINUX_BOT_PAGE_ID:
+				linuxNewsBot.handleFacebookMessage(message);
+				break;
+			case APPLE_BOT_PAGE_ID:
+				appleNewsBot.handleFacebookMessage(message);
+				break;
+			// ...
+		};
+	});
+});
+```
+
 ## Examples
 
 Check the `examples` directory to see more demos of:

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Subscribe to an event emitted by the bot, and execute a callback when those even
 | `delivery` | The bot received a confirmation that your message was delivered to the user |
 | `read` | The bot received a confirmation that your message was read by the user |
 | `authentication` | A user has started a conversation with the bot using a "Send to Messenger" button |
+| `referral` | A user that already has a thread with the bot starts a conversation. [more](https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_referrals) |
 
 You can also subscribe to specific postbacks and quick replies by using a namespace. For example `postback:ADD_TO_CART` subscribes only to the postback event containing the `ADD_TO_CART` payload.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Creating a Giphy Chat Bot in 3 minutes:
 
 - Install BootBot via NPM, create a new `index.js`, require BootBot and create a new bot instance using your Facebook Page's / App's `accessToken`, `verifyToken` and `appSecret`:
 
+**Note:** If you don't know how to get these tokens, take a look at Facebook's [Quick Start Guide](https://developers.facebook.com/docs/messenger-platform/guides/quick-start) or check out [this issue](https://github.com/Charca/bootbot/issues/56).
+
 ```javascript
 // index.js
 'use strict';

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ BootBot is a simple but powerful JavaScript Framework to build Facebook Messenge
 |---|---|---|---|---|---|---|---|
 
 
-**[ :speech_balloon: Questions / Comments? Join our Slack channel!](https://bootbot.slack.com/shared_invite/MTQwODA0MDU2NDUxLTE0ODcwMTQ1MjgtNTc3MDVhOWRjZQ)**
+**[ :speech_balloon: Questions / Comments? Join our Slack channel!](https://bootbot-slack-channel.herokuapp.com/)**
 
 ## Features
 

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -288,7 +288,7 @@ class BootBot extends EventEmitter {
           title: button,
           payload: 'BOOTBOT_BUTTON_' + normalizeString(button)
         };
-      } else if (button && button.title) {
+      } else if (button && button.type) {
         return button;
       }
       return {};

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -19,7 +19,8 @@ class BootBot extends EventEmitter {
     this.appSecret = options.appSecret;
     this.broadcastEchoes = options.broadcastEchoes || false;
     this.app = express();
-    this.webhook = options.webhook || "/webhook";
+    this.webhook = options.webhook || '/webhook';
+    this.webhook = this.webhook.charAt(0) !== '/' ? `/${this.webhook}` : this.webhook;
     this.app.use(bodyParser.json({ verify: this._verifyRequestSignature.bind(this) }));
     this._hearMap = [];
     this._conversations = [];
@@ -453,7 +454,7 @@ class BootBot extends EventEmitter {
         .digest('hex');
 
       if (signatureHash != expectedHash) {
-        throw new Error("Couldn't validate the request signature.");
+        throw new Error('Couldn\'t validate the request signature.');
       }
     }
   }

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -387,6 +387,7 @@ class BootBot extends EventEmitter {
     return (typeof recipient === 'object') ? recipient : { id: recipient };
   }
 
+
   _initWebhook() {
     this.app.get(this.webhook, (req, res) => {
       if (req.query['hub.mode'] === 'subscribe' && req.query['hub.verify_token'] === this.verifyToken) {
@@ -404,40 +405,44 @@ class BootBot extends EventEmitter {
         return;
       }
 
-      // Iterate over each entry. There may be multiple if batched.
-      data.entry.forEach((entry) => {
-        // Iterate over each messaging event
-        entry.messaging.forEach((event) => {
-          if (event.message && event.message.is_echo && !this.broadcastEchoes) {
-            return;
-          }
-          if (event.optin) {
-            this._handleEvent('authentication', event);
-          } else if (event.message && event.message.text) {
-            this._handleMessageEvent(event);
-            if (event.message.quick_reply) {
-              this._handleQuickReplyEvent(event);
-            }
-          } else if (event.message && event.message.attachments) {
-            this._handleAttachmentEvent(event);
-          } else if (event.postback) {
-            this._handlePostbackEvent(event);
-          } else if (event.delivery) {
-            this._handleEvent('delivery', event);
-          } else if (event.read) {
-            this._handleEvent('read', event);
-          } else if (event.account_linking) {
-            this._handleEvent('account_linking', event);
-          } else if (event.referral) {
-            this._handleEvent('referral', event);
-          } else {
-            console.log('Webhook received unknown event: ', event);
-          }
-        });
-      });
+      this.handleFacebookData(data);
 
       // Must send back a 200 within 20 seconds or the request will time out.
       res.sendStatus(200);
+    }).bind(this);
+  }
+
+  handleFacebookData(data) {
+    // Iterate over each entry. There may be multiple if batched.
+    data.entry.forEach((entry) => {
+      // Iterate over each messaging event
+      entry.messaging.forEach((event) => {
+        if (event.message && event.message.is_echo && !this.broadcastEchoes) {
+          return;
+        }
+        if (event.optin) {
+          this._handleEvent('authentication', event);
+        } else if (event.message && event.message.text) {
+          this._handleMessageEvent(event);
+          if (event.message.quick_reply) {
+            this._handleQuickReplyEvent(event);
+          }
+        } else if (event.message && event.message.attachments) {
+          this._handleAttachmentEvent(event);
+        } else if (event.postback) {
+          this._handlePostbackEvent(event);
+        } else if (event.delivery) {
+          this._handleEvent('delivery', event);
+        } else if (event.read) {
+          this._handleEvent('read', event);
+        } else if (event.account_linking) {
+          this._handleEvent('account_linking', event);
+        } else if (event.referral) {
+          this._handleEvent('referral', event);
+        } else {
+          console.log('Webhook received unknown event: ', event);
+        }
+      });
     });
   }
 

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -19,6 +19,7 @@ class BootBot extends EventEmitter {
     this.appSecret = options.appSecret;
     this.broadcastEchoes = options.broadcastEchoes || false;
     this.app = express();
+    this.webhook = options.webhook || "/webhook";
     this.app.use(bodyParser.json({ verify: this._verifyRequestSignature.bind(this) }));
     this._hearMap = [];
     this._conversations = [];
@@ -30,7 +31,7 @@ class BootBot extends EventEmitter {
     this.server = this.app.listen(this.app.get('port'), () => {
       const portNum = this.app.get('port');
       console.log('BootBot running on port', portNum);
-      console.log(`Facebook Webhook running on localhost:${portNum}/webhook`);
+      console.log(`Facebook Webhook running on localhost:${portNum}${this.webhook}`);
     });
   }
 
@@ -386,7 +387,7 @@ class BootBot extends EventEmitter {
   }
 
   _initWebhook() {
-    this.app.get('/webhook', (req, res) => {
+    this.app.get(this.webhook, (req, res) => {
       if (req.query['hub.mode'] === 'subscribe' && req.query['hub.verify_token'] === this.verifyToken) {
         console.log('Validation Succeded.')
         res.status(200).send(req.query['hub.challenge']);
@@ -396,7 +397,7 @@ class BootBot extends EventEmitter {
       }
     });
 
-    this.app.post('/webhook', (req, res) => {
+    this.app.post(this.webhook, (req, res) => {
       var data = req.body;
       if (data.object !== 'page') {
         return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootbot",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Facebook Messenger Bot Framework",
   "main": "index.js",
   "scripts": {

--- a/test/BootBot.spec.js
+++ b/test/BootBot.spec.js
@@ -48,6 +48,72 @@ describe('BootBot', () => {
     expect(spy.calledWith(expected)).to.equal(true);
   });
 
+  it('responds to a hear', () => {
+    const comment = sinon.spy();
+    bot.hear(/hello/, (payload, chat) => {
+      comment();
+    });
+    const data = {
+      "object": "page",
+      "entry": [
+        {
+          "id": "PAGE_ID",
+          "time": 1458692752478,
+          "messaging": [
+            {
+              "sender": {
+                "id": "USER_ID"
+              },
+              "recipient": {
+                "id": "PAGE_ID"
+              },
+              "timestamp": 1458692752478,
+              "message": {
+                "mid": "mid.1457764197618:41d102a3e1ae206a38",
+                "text": "hello, world!"
+              }
+            }
+          ]
+        }
+      ]
+    };
+    bot.handleFacebookData(data);
+    expect(comment.calledOnce).to.equal(true);
+  });
+
+  it('hear doesn\'t respond on non-match', () => {
+    const comment = sinon.spy();
+    bot.hear(/hello/, (payload, chat) => {
+      comment();
+    });
+    const data = {
+      "object": "page",
+      "entry": [
+        {
+          "id": "PAGE_ID",
+          "time": 1458692752478,
+          "messaging": [
+            {
+              "sender": {
+                "id": "USER_ID"
+              },
+              "recipient": {
+                "id": "PAGE_ID"
+              },
+              "timestamp": 1458692752478,
+              "message": {
+                "mid": "mid.1457764197618:41d102a3e1ae206a38",
+                "text": "goodbye, world!"
+              }
+            }
+          ]
+        }
+      ]
+    };
+    bot.handleFacebookData(data);
+    expect(comment.called).to.equal(false);
+  });
+
   it('can send a text message with quick replies', () => {
     const spy = sinon.spy(bot, 'sendRequest');
     const text = 'Hello world!';


### PR DESCRIPTION
I want to be able to create multiple bots on different pages and forward to the correct bot based on the page id from the incoming message.
Currently this is impossible because the message handling is coupled with the express request handling.
This opens that up and also makes testing easier without needing to create an express instance to test message handling.
The tests are ugly, but I think useful.