### PR TITLE
Allow passing message array into say()

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -252,6 +252,10 @@ class BootBot extends EventEmitter {
       }
     } else if (message && message.attachment) {
       return this.sendAttachment(recipientId, message.attachment, message.url, message.quickReplies, options);
+    } else if (Array.isArray(message)) {
+      return message.reduce((promise, msg) => {
+        return promise.then(() => this.say(msg));
+      }, Promise.resolve());
     }
     console.error('Invalid format for .say() message.');
   }

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -254,7 +254,7 @@ class BootBot extends EventEmitter {
       return this.sendAttachment(recipientId, message.attachment, message.url, message.quickReplies, options);
     } else if (Array.isArray(message)) {
       return message.reduce((promise, msg) => {
-        return promise.then(() => this.say(msg));
+        return promise.then(() => this.say(recipientId, msg, options));
       }, Promise.resolve());
     }
     console.error('Invalid format for .say() message.');


### PR DESCRIPTION
For now if we need to send multiple messages, we have to do this:

```js
chat.say('hello').then(() => {
    chat.say('world').then(() => {
        chat.say('from bootbot');
    });
});
```

This is tedious, especially when you want to pass in options.

In this PR, I modified the `say()` method so that it can also take a message array:

```js
chat.say(['hello', 'world', 'from bootbot']);
```

or with options:

```js
chat.say(['hello', 'world', 'from bootbot'], {typing: true});
```