### PR TITLE
Added greeting objectname in setGreetingText

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -194,7 +194,7 @@ class BootBot extends EventEmitter {
       locale: 'default',
       text
     }];
-    return this.sendProfileRequest({ greeting });
+    return this.sendProfileRequest({ "greeting": greeting });
   }
 
   setGetStartedButton(action) {


### PR DESCRIPTION
bot.setGreetingText didn't work for me. According to the messenger profile API docs objectkey "greeting" is required for the array. 