### PR TITLE
Don't remove buttons without title in _formatButtons

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -288,7 +288,7 @@ class BootBot extends EventEmitter {
           title: button,
           payload: 'BOOTBOT_BUTTON_' + normalizeString(button)
         };
-      } else if (button && button.title) {
+      } else if (button && button.type) {
         return button;
       }
       return {};


### PR DESCRIPTION
I've spent a good hour and an half trying to understand why facebook was returning an error
when I was trying to send a button template with a single login button. Turns out it was a library bug :)

I'm not sure why the `_formatButtons` methods would **silently** discards buttons at all, in my opinion
it should send them all and let facebook return an error if some required button attributes are missing; or at the very list show a warning for discarded buttons!

But, to have a behaviour as similar as possible to the current one, I've just changed the check from `title` (not used in all buttons) to `type` (required for all button types).

The commit message has more details:

> The _formatButton method, called by sendButtonTemplate and sendListTemplate,
discarded all buttons without a 'title' key.
But not all buttons usable in those methods are required to have a title:
notably, the login and logout buttons of the account linking flow must
only specify the 'type' and 'url' keys.
>
> This resulted in an error when trying to send a button template with only
a login button, for example using:
>
>    ```
>    bot.say({
>      text: 'In order to use the bot, you must authenticate to our website',
>      buttons: [{type: 'account_link', url: '<myLoginUrl>'}]
>    })
>    ```
>
>  because the bot *silently* discarded the only button, causing
Facebook to return an error due to a request for a button template message
without buttons.