### PR TITLE
Added mandatory messaging_type to requests

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -117,7 +117,8 @@ class BootBot extends EventEmitter {
     const req = () => (
       this.sendRequest({
         recipient,
-        message
+        message,
+        messaging_type: options && options.messaging_type || 'RESPONSE'
       }).then((json) => {
         if (typeof onDelivery === 'function') {
           this.once('delivery', onDelivery);

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -118,7 +118,9 @@ class BootBot extends EventEmitter {
       this.sendRequest({
         recipient,
         message,
-        messaging_type: options && options.messaging_type || 'RESPONSE'
+        messaging_type: options && options.messaging_type || 'RESPONSE',
+        tag: options && options.messaging_type == 'MESSAGE_TAG' && options.tag || undefined,
+        notification_type: options && options.notification_type || 'REGULAR'
       }).then((json) => {
         if (typeof onDelivery === 'function') {
           this.once('delivery', onDelivery);


### PR DESCRIPTION
This is very needed so I thought I could help by adding it. It's such a simple PR but mandatory after [May 7, 2018](https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types). 