### PR TITLE
Add ability to regex postbacks

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -23,6 +23,7 @@ class BootBot extends EventEmitter {
     this.webhook = this.webhook.charAt(0) !== '/' ? `/${this.webhook}` : this.webhook;
     this.app.use(bodyParser.json({ verify: this._verifyRequestSignature.bind(this) }));
     this._hearMap = [];
+    this._postbackMap = [];
     this._conversations = [];
   }
 
@@ -270,6 +271,12 @@ class BootBot extends EventEmitter {
     return this;
   }
 
+  postback(keywords, callback) {
+    keywords = Array.isArray(keywords) ? keywords : [keywords];
+    keywords.forEach(keyword => this._postbackMap.push({ keyword, callback }));
+    return this;
+  }
+
   module(factory) {
     return factory.apply(this, [this]);
   }
@@ -364,7 +371,30 @@ class BootBot extends EventEmitter {
   _handlePostbackEvent(event) {
     if (this._handleConversationResponse('postback', event)) { return; }
     const payload = event.postback.payload;
-    if (payload) {
+    const senderId = event.sender.id;
+      if (payload) {
+        let captured = false;
+
+        this._postbackMap.forEach(postback => {
+            if (typeof postback.keyword === 'string' && postback.keyword.toLowerCase() === payload.toLowerCase()) {
+                const res = postback.callback.apply(this, [event, new Chat(this, senderId), {
+                    keyword: postback.keyword,
+                    captured
+                }]);
+                captured = true;
+                return res;
+            } else if (postback.keyword instanceof RegExp && postback.keyword.test(payload)) {
+                const res = postback.callback.apply(this, [event, new Chat(this, senderId), {
+                    keyword: postback.keyword,
+                    match: payload.match(postback.keyword),
+                    captured
+                }]);
+                captured = true;
+                return res;
+            }
+        });
+      if (captured) return;
+
       this._handleEvent(`postback:${payload}`, event);
     }
     this._handleEvent('postback', event);


### PR DESCRIPTION
There was an open issue #87 which asked for ability to regex postbacks. Since I also really needed this functionality - I went ahead and did a quick implementation to get the discussion going. 

The api is a complete copy of `bot.hear()`. This also takes in either a `string | RegExp` or an array of such, and makes a map to verify later. 

I can go ahead and add tests for this, if this is something we'd want to move forwards with. 

//cc @mraaroncruz @PandawanFr as both of you originally requested this feature.
