### PR TITLE
Added jsdoc comments

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -77,7 +77,7 @@ class BootBot extends EventEmitter {
   /**
    * @param {Recipient|Object} recipientId Recipient object or ID.
    * @param {String} text 
-   * @param {Array.<QuickReply>|Array.<String>} quickReplies Array of strings or quick_reply objects
+   * @param {Array.<QuickReply|String>} quickReplies Array of strings or quick_reply objects
    * @param {SendMessageOptions} [options] 
    */
   sendTextMessage(recipientId, text, quickReplies, options) {
@@ -121,7 +121,6 @@ class BootBot extends EventEmitter {
    */
 
   /**
-   * 
    * @param {Recipient|String} recipientId
    * @param {Array.<Element>} elements 
    * @param {SendMessageOptions} [options] 
@@ -218,7 +217,6 @@ class BootBot extends EventEmitter {
    * @param {Recipient|String} recipientId Recipient object or ID.
    * @param {Message} message The message to send.
    * @param {SendMessageOptions} [options] 
-   * @return {Promise}
    */
   sendMessage(recipientId, message, options) {
     const recipient = this._createRecipient(recipientId);
@@ -247,7 +245,6 @@ class BootBot extends EventEmitter {
   }
 
   /**
-   * 
    * @param {Object} body The request body object.
    * @param {String} endpoint Messenger API endpoint
    * @param {String} method HTTP method.

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -9,6 +9,16 @@ const fetch = require('node-fetch');
 const normalizeString = require('./utils/normalize-string');
 
 class BootBot extends EventEmitter {
+  /**
+   * Creates a new BootBot instance. Instantiates the new express app and all required webhooks. options param must contain all tokens and app secret of your Facebook app. Optionally, set broadcastEchoes to true if you want the messages your bot send to be echoed back to it (you probably don't need this feature unless you have multiple bots running on the same Facebook page).
+   * If you want to specify a custom endpoint name for your webhook, you can do it with the webhook option.
+   * @param {Object} options
+   * @param {String} options.accessToken
+   * @param {String} options.verifyToken
+   * @param {String} options.appSecret
+   * @param {String} [options.webhook=/webhook]
+   * @param {Boolean} [options.broadcastEchoes=false]
+   */
   constructor(options) {
     super();
     if (!options || (options && (!options.accessToken || !options.verifyToken || !options.appSecret))) {
@@ -26,6 +36,10 @@ class BootBot extends EventEmitter {
     this._conversations = [];
   }
 
+  /**
+   * Starts the express server on the specified port. Defaults port to 3000.
+   * @param {Number} [port=3000]
+   */
   start(port) {
     this._initWebhook();
     this.app.set('port', port || 3000);
@@ -36,10 +50,36 @@ class BootBot extends EventEmitter {
     });
   }
 
+  /**
+   * Closes the express server (calls `.close()` on the server instance).
+   */
   close() {
     this.server.close();
   }
 
+  /**
+   * See https://developers.facebook.com/docs/messenger-platform/reference/send-api/quick-replies/#quick_reply
+   * @typedef {Object} QuickReply
+   * @property {String} content_type
+   * @property {String} title
+   * @property {String|Number} payload
+   * @property {String} [image_url]
+   */
+
+  
+  /**
+   * @typedef {Object} SendMessageOptions
+   * @property {Boolean|Number} [typing=false] Send a typing indicator before sending the message. If set to true, it will automatically calculate how long it lasts based on the message length. If it's a number, it will show the typing indicator for that amount of milliseconds (max. 20000 - 20 seconds)
+   * @property {Function} [onDelivery] Callback that will be executed when the message is received by the user. Receives params: (payload, chat, data)
+   * @property {Function} [onRead] Callback that will be executed when the message is read by the user. Receives params: (payload, chat, data)
+   */
+  
+  /**
+   * @param {Recipient|Object} recipientId Recipient object or ID.
+   * @param {String} text 
+   * @param {Array.<QuickReply>|Array.<String>} quickReplies Array of strings or quick_reply objects
+   * @param {SendMessageOptions} [options] 
+   */
   sendTextMessage(recipientId, text, quickReplies, options) {
     const message = { text };
     const formattedQuickReplies = this._formatQuickReplies(quickReplies);
@@ -49,6 +89,18 @@ class BootBot extends EventEmitter {
     return this.sendMessage(recipientId, message, options);
   }
 
+  /**
+   * A button can be one of multiple types, see Messenger API docs for details.
+   * https://developers.facebook.com/docs/messenger-platform/reference
+   * @typedef {Object} Button
+   */
+
+  /**
+   * @param {Recipient|String} recipientId
+   * @param {String} text Message to be sent.
+   * @param {Array.<String|Button>} buttons
+   * @param {SendMessageOptions} [options] 
+   */
   sendButtonTemplate(recipientId, text, buttons, options) {
     const payload = {
       template_type: 'button',
@@ -59,6 +111,21 @@ class BootBot extends EventEmitter {
     return this.sendTemplate(recipientId, payload, options);
   }
 
+  /**
+   * @typedef {Object} Element
+   * @property {String} title The title to display in the template. 80 character limit.
+   * @property {String} [subtitle] The subtitle to display in the template. 80 character limit.
+   * @property {String} [image_url] The URL of the image to display in the template.
+   * @property {Object} [default_action] The default action executed when the template is tapped. Accepts the same properties as URL button, except title.
+   * @property {Array.<Button>} buttons An array of buttons to append to the template. A maximum of 3 buttons per element is supported.
+   */
+
+  /**
+   * 
+   * @param {Recipient|String} recipientId
+   * @param {Array.<Element>} elements 
+   * @param {SendMessageOptions} [options] 
+   */
   sendGenericTemplate(recipientId, elements, options) {
     const payload = {
       template_type: 'generic',
@@ -68,6 +135,13 @@ class BootBot extends EventEmitter {
     return this.sendTemplate(recipientId, payload, options);
   }
 
+  /**
+   * @param {Recipient|String} recipientId 
+   * @param {Array.<Element>} elements 
+   * @param {Array.<String|Button>} buttons An array with one element: string or button object.
+   * @param {SendMessageOptions} [options]
+   * @param {String} [options.topElementStyle]
+   */
   sendListTemplate(recipientId, elements, buttons, options) {
     const payload = {
       template_type: 'list',
@@ -78,6 +152,12 @@ class BootBot extends EventEmitter {
     return this.sendTemplate(recipientId, payload, options);
   }
 
+  /**
+   * Use this method if you want to send a custom template payload, like a receipt template or an airline itinerary template.
+   * @param {Recipient|String} recipientId 
+   * @param {Object} payload The template payload.
+   * @param {SendMessageOptions} [options]
+   */
   sendTemplate(recipientId, payload, options) {
     const message = {
       attachment: {
@@ -88,6 +168,13 @@ class BootBot extends EventEmitter {
     return this.sendMessage(recipientId, message, options);
   }
 
+  /**
+   * @param {Recipient|String} recipientId 
+   * @param {String} type Must be 'image', 'audio', 'video' or 'file'.
+   * @param {String} url URL of the attachment.
+   * @param {Array.<QuickReply>} quickReplies 
+   * @param {SendMessageOptions} options 
+   */
   sendAttachment(recipientId, type, url, quickReplies, options) {
     const message = {
       attachment: {
@@ -102,6 +189,13 @@ class BootBot extends EventEmitter {
     return this.sendMessage(recipientId, message, options);
   }
 
+  /**
+   * Send an action.
+   * To send a typing indicator in a more convenient way, see the .sendTypingIndicator method.
+   * @param {Recipient|String} recipientId Recipient object or ID.
+   * @param {String} action One of 'mark_seen', 'typing_on' or 'typing_off'
+   * @param {SendMessageOptions} [options] NOT USED.
+   */
   sendAction(recipientId, action, options) {
     const recipient = this._createRecipient(recipientId);
     return this.sendRequest({
@@ -110,6 +204,22 @@ class BootBot extends EventEmitter {
     });
   }
 
+  /**
+   * A message object to be sent to a recipient.
+   * @typedef {Object} Message
+   * @property {String} text Message text. Previews will not be shown for the URLs in this field. Use attachment instead. Must be UTF-8 and has a 2000 character limit. text or attachment must be set.
+   * @property {Attachment} attachment attachment object. Previews the URL. Used to send messages with media or Structured Messages. text or attachment must be set.
+   * @property {Array.<QuickReply>} [quick_reply] Array of quick_reply to be sent with messages.
+   * @property {String} [metadata] Custom string that is delivered as a message echo. 1000 character limit.
+   */
+
+  /**
+   * Use this method if you want to send a custom message object.
+   * @param {Recipient|String} recipientId Recipient object or ID.
+   * @param {Message} message The message to send.
+   * @param {SendMessageOptions} [options] 
+   * @return {Promise}
+   */
   sendMessage(recipientId, message, options) {
     const recipient = this._createRecipient(recipientId);
     const onDelivery = options && options.onDelivery;
@@ -136,6 +246,13 @@ class BootBot extends EventEmitter {
     return req();
   }
 
+  /**
+   * 
+   * @param {Object} body The request body object.
+   * @param {String} endpoint Messenger API endpoint
+   * @param {String} method HTTP method.
+   * @returns {Promise}
+   */
   sendRequest(body, endpoint, method) {
     endpoint = endpoint || 'messages';
     method = method || 'POST';
@@ -157,6 +274,12 @@ class BootBot extends EventEmitter {
     .catch(err => console.log(`Error sending message: ${err}`));
   }
 
+  /**
+   * Thread API has been replaced by the Messenger Profile API.
+   * Please update your code to use the sendProfileRequest() method instead.
+   * @param {Object} body 
+   * @param {String} method 
+   */
   sendThreadRequest(body, method) {
     console.warning(`
       sendThreadRequest: Dreprecation warning. Thread API has been replaced by the Messenger Profile API.
@@ -165,10 +288,19 @@ class BootBot extends EventEmitter {
     return this.sendRequest(body, 'thread_settings', method);
   }
 
+  /**
+   * @param {Object} body The request body.
+   * @param {String} method HTTP method.
+   */
   sendProfileRequest(body, method) {
     return this.sendRequest(body, 'messenger_profile', method);
   }
 
+  /**
+   * Convinient method to send a typing_on action and then a typing_off action after milliseconds to simulate the bot is actually typing. Max value is 20000 (20 seconds).
+   * @param {Recipient|String} recipientId 
+   * @param {Number} milliseconds 
+   */
   sendTypingIndicator(recipientId, milliseconds) {
     const timeout = isNaN(milliseconds) ? 0 : milliseconds;
     if (milliseconds > 20000) {
@@ -182,6 +314,11 @@ class BootBot extends EventEmitter {
     });
   }
 
+  /**
+   * Returns a Promise that contains the user's profile information.
+   * @param {String} userId
+   * @returns {Promise}
+   */
   getUserProfile(userId) {
     const url = `https://graph.facebook.com/v2.6/${userId}?fields=first_name,last_name,profile_pic,locale,timezone,gender&access_token=${this.accessToken}`;
     return fetch(url)
@@ -189,6 +326,11 @@ class BootBot extends EventEmitter {
       .catch(err => console.log(`Error getting user profile: ${err}`));
   }
 
+  /**
+   * Set a greeting text for new conversations. The Greeting Text is only rendered the first time the user interacts with a the Page on Messenger.
+   * Facebook docs: https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/greeting
+   * @param {String|Array.<Object>} text Greeting text, or an array of objects to support multiple locales. For more info on the format of these objects, see: https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/greeting
+   */
   setGreetingText(text) {
     const greeting = (typeof text !== 'string') ? text : [{
       locale: 'default',
@@ -197,6 +339,11 @@ class BootBot extends EventEmitter {
     return this.sendProfileRequest({ greeting });
   }
 
+  /**
+   * React to a user starting a conversation with the bot by clicking the Get Started button.
+   * Facebook docs: https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/get-started-button
+   * @param {String|Function} action If action is a string, the Get Started button postback will be set to that string. If it's a function, that callback will be executed when a user clicks the Get Started button.
+   */
   setGetStartedButton(action) {
     const payload = (typeof action === 'string') ? action : 'BOOTBOT_GET_STARTED';
     if (typeof action === 'function') {
@@ -209,6 +356,9 @@ class BootBot extends EventEmitter {
     });
   }
 
+  /**
+   * Removes the Get Started button call to action.
+   */
   deleteGetStartedButton() {
     return this.sendProfileRequest({
       fields: [
@@ -217,6 +367,12 @@ class BootBot extends EventEmitter {
     }, 'DELETE');
   }
 
+  /**
+   * Creates a Persistent Menu that is available at any time during the conversation. The buttons param can be an array of strings, button objects, or locale objects.
+   * Facebook docs: https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/persistent-menu
+   * @param {Array.<String|Button>} buttons If buttons is an array of objects containing a locale attribute, it will be used as-is, expecting it to be an array of localized menues. For more info on the format of these objects, see the documentation.
+   * @param {boolean} [disableInput=false] If disableInput is set to true, it will disable user input in the menu. The user will only be able to interact with the bot via the menu, postbacks, buttons and webviews.
+   */
   setPersistentMenu(buttons, disableInput) {
     if (buttons && buttons[0] && buttons[0].locale !== undefined) {
       // Received an array of locales, send it as-is.
@@ -233,6 +389,9 @@ class BootBot extends EventEmitter {
     });
   }
 
+  /**
+   * Removes the Persistent Menu.
+   */
   deletePersistentMenu() {
     return this.sendProfileRequest({
       fields: [
@@ -241,6 +400,13 @@ class BootBot extends EventEmitter {
     }, 'DELETE');
   }
 
+  /**
+   * Send a message to the user. The .say() method can be used to send text messages, button messages, messages with quick replies or attachments. If you want to send a different type of message (like a generic template), see the Send API method for that specific type of message.
+   * @param {Recipient|String} recipientId Recipient or recipient's ID.
+   * @param {String|Array|Message} message 
+   * @param {SendMessageOptions} options
+   * @returns {Promise}
+   */
   say(recipientId, message, options) {
     if (typeof message === 'string') {
       return this.sendTextMessage(recipientId, message, [], options);
@@ -264,16 +430,30 @@ class BootBot extends EventEmitter {
     console.error('Invalid format for .say() message.');
   }
 
+  /**
+   * A convinient method to subscribe to message events containing specific keywords. The keyword param can be a string, a regex or an array of both strings and regexs that will be tested against the received message. If the bot receives a message that matches any of the keywords, it will execute the specified callback. String keywords are case-insensitive, but regular expressions are not case-insensitive by default, if you want them to be, specify the i flag.
+   * @param {String|Regex|Array} keywords
+   * @param {Function} callback 
+   */
   hear(keywords, callback) {
     keywords = Array.isArray(keywords) ? keywords : [keywords];
     keywords.forEach(keyword => this._hearMap.push({ keyword, callback }));
     return this;
   }
 
+  /**
+   * Modules are simple functions that you can use to organize your code in different files and folders.
+   * @param {Function} factory Called immediatly and receives the bot instance as its only parameter.
+   */
   module(factory) {
     return factory.apply(this, [this]);
   }
 
+  /**
+   * Starts a new conversation with the user.
+   * @param {Recipient|String} recipientId 
+   * @param {Function} factory Executed immediately receiving the convo instance as it's only param.
+   */
   conversation(recipientId, factory) {
     if (!recipientId || !factory || typeof factory !== 'function') {
       return console.error(`You need to specify a recipient and a callback to start a conversation`);
@@ -288,6 +468,10 @@ class BootBot extends EventEmitter {
     return convo;
   }
 
+  /**
+   * Used to format an array of button titles to Button objects.
+   * @param {Array.<String|Button>} buttons If there are Button objects in the array they are not modified.
+   */
   _formatButtons(buttons) {
     return buttons && buttons.map((button) => {
       if (typeof button === 'string') {
@@ -303,6 +487,10 @@ class BootBot extends EventEmitter {
     });
   }
 
+  /**
+   * Used to format QuickReply objects or titles into the correct format to be consumed by the Facebook API.
+   * @param {Array.<QuickReply|String>} quickReplies
+   */
   _formatQuickReplies(quickReplies) {
     return quickReplies && quickReplies.map((reply) => {
       if (typeof reply === 'string') {
@@ -321,6 +509,11 @@ class BootBot extends EventEmitter {
     });
   }
 
+  /**
+   * @param {String} type 
+   * @param {Object} event 
+   * @param {Object} data 
+   */
   _handleEvent(type, event, data) {
     const recipient = (type === 'authentication' && !event.sender) ? { user_ref: event.optin.user_ref } : event.sender.id;
     const chat = new Chat(this, recipient);
@@ -391,6 +584,17 @@ class BootBot extends EventEmitter {
     return captured;
   }
 
+  /**
+   * A recipient of a message.
+   * @typedef {Object} Recipient
+   * @property {String} id The recipient's unique ID.
+   */
+
+  /**
+   * Create a recipient object.
+   * @param {Object|String} recipient A recipient object of ID.
+   * @returns {Recipient}
+   */
   _createRecipient(recipient) {
     return (typeof recipient === 'object') ? recipient : { id: recipient };
   }
@@ -420,6 +624,10 @@ class BootBot extends EventEmitter {
     }).bind(this);
   }
 
+  /**
+   * Use this to send a message from a parsed webhook message directly to your bot.
+   * @param {Object} data
+   */
   handleFacebookData(data) {
     // Iterate over each entry. There may be multiple if batched.
     data.entry.forEach((entry) => {

--- a/lib/Chat.js
+++ b/lib/Chat.js
@@ -1,7 +1,12 @@
 'use strict';
 const EventEmitter = require('eventemitter3');
+const BootBot = require('./BootBot');
 
 class Chat extends EventEmitter {
+  /**
+   * @param {BootBot} bot Bot instance.
+   * @param {String} userId 
+   */
   constructor(bot, userId) {
     super();
     if (!bot || !userId) {
@@ -11,54 +16,157 @@ class Chat extends EventEmitter {
     this.userId = userId;
   }
 
+  /**
+   * @typedef {Object} SendMessageOptions
+   * @property {Boolean|Number} [typing=false] Send a typing indicator before sending the message. If set to true, it will automatically calculate how long it lasts based on the message length. If it's a number, it will show the typing indicator for that amount of milliseconds (max. 20000 - 20 seconds)
+   * @property {Function} [onDelivery] Callback that will be executed when the message is received by the user. Receives params: (payload, chat, data)
+   * @property {Function} [onRead] Callback that will be executed when the message is read by the user. Receives params: (payload, chat, data)
+   */
+
+  /**
+   * A message object to be sent to a recipient.
+   * @typedef {Object} Message
+   * @property {String} text Message text. Previews will not be shown for the URLs in this field. Use attachment instead. Must be UTF-8 and has a 2000 character limit. text or attachment must be set.
+   * @property {Attachment} attachment attachment object. Previews the URL. Used to send messages with media or Structured Messages. text or attachment must be set.
+   * @property {Array.<QuickReply>} [quick_reply] Array of quick_reply to be sent with messages.
+   * @property {String} [metadata] Custom string that is delivered as a message echo. 1000 character limit.
+   */
+
+  /**
+   * @param {Message} message
+   * @param {SendMessageOptions} options
+   */
   say(message, options) {
     return this.bot.say(this.userId, message, options);
   }
 
+  /**
+   * See https://developers.facebook.com/docs/messenger-platform/reference/send-api/quick-replies/#quick_reply
+   * @typedef {Object} QuickReply
+   * @property {String} content_type
+   * @property {String} title
+   * @property {String|Number} payload
+   * @property {String} [image_url]
+   */
+
+  /**
+   * @param {String} text 
+   * @param {Array.<QuickReply|String>} quickReplies Array of strings or quick_reply objects
+   * @param {SendMessageOptions} [options] 
+   */
   sendTextMessage(text, quickReplies, options) {
     return this.bot.sendTextMessage(this.userId, text, quickReplies, options);
   }
 
+  /**
+   * A button can be one of multiple types, see Messenger API docs for details.
+   * https://developers.facebook.com/docs/messenger-platform/reference
+   * @typedef {Object} Button
+   */
+
+  /**
+   * @param {String} text Message to be sent.
+   * @param {Array.<String|Button>} buttons
+   * @param {SendMessageOptions} [options] 
+   */
   sendButtonTemplate(text, buttons, options) {
     return this.bot.sendButtonTemplate(this.userId, text, buttons, options);
   }
 
+  /**
+   * @typedef {Object} Element
+   * @property {String} title The title to display in the template. 80 character limit.
+   * @property {String} [subtitle] The subtitle to display in the template. 80 character limit.
+   * @property {String} [image_url] The URL of the image to display in the template.
+   * @property {Object} [default_action] The default action executed when the template is tapped. Accepts the same properties as URL button, except title.
+   * @property {Array.<Button>} buttons An array of buttons to append to the template. A maximum of 3 buttons per element is supported.
+   */
+
+  /**
+   * @param {Array.<Element>} cards 
+   * @param {SendMessageOptions} [options] 
+   */
   sendGenericTemplate(cards, options) {
     return this.bot.sendGenericTemplate(this.userId, cards, options);
   }
 
+  /**
+   * @param {Array.<Element>} elements 
+   * @param {Array.<String|Button>} buttons An array with one element: string or button object.
+   * @param {SendMessageOptions} [options]
+   * @param {String} [options.topElementStyle]
+   */
   sendListTemplate(elements, buttons, options) {
     return this.bot.sendListTemplate(this.userId, elements, buttons, options);
   }
 
+  /**
+   * Use this method if you want to send a custom template payload, like a receipt template or an airline itinerary template.
+   * @param {Object} payload The template payload.
+   * @param {SendMessageOptions} [options]
+   */
   sendTemplate(payload, options) {
     return this.bot.sendTemplate(this.userId, payload, options);
   }
 
+  /**
+   * @param {String} type Must be 'image', 'audio', 'video' or 'file'.
+   * @param {String} url URL of the attachment.
+   * @param {Array.<QuickReply>} quickReplies 
+   * @param {SendMessageOptions} options 
+   */
   sendAttachment(type, url, quickReplies, options) {
     return this.bot.sendAttachment(this.userId, type, url, quickReplies, options);
   }
 
+  /**
+   * Send an action.
+   * To send a typing indicator in a more convenient way, see the .sendTypingIndicator method.
+   * @param {String} action One of 'mark_seen', 'typing_on' or 'typing_off'
+   * @param {SendMessageOptions} [options] NOT USED.
+   */
   sendAction(action, options) {
     return this.bot.sendAction(this.userId, action, options);
   }
 
+  /**
+   * Use this method if you want to send a custom message object.
+   * @param {Message} message The message to send.
+   * @param {SendMessageOptions} [options] 
+   */
   sendMessage(message, options) {
     return this.bot.sendMessage(this.userId, message, options);
   }
 
+  /**
+   * @param {Object} body The request body object.
+   * @param {String} endpoint Messenger API endpoint
+   * @param {String} method HTTP method.
+   * @returns {Promise}
+   */
   sendRequest(body, endpoint, method) {
     return this.bot.sendRequest(body, endpoint, method);
   }
 
+  /**
+   * Convinient method to send a typing_on action and then a typing_off action after milliseconds to simulate the bot is actually typing. Max value is 20000 (20 seconds).
+   * @param {Number} milliseconds 
+   */
   sendTypingIndicator(milliseconds) {
     return this.bot.sendTypingIndicator(this.userId, milliseconds);
   }
 
+  /**
+   * Returns a Promise that contains the user's profile information.
+   */
   getUserProfile() {
     return this.bot.getUserProfile(this.userId);
   }
 
+  /**
+   * Starts a new conversation with the user.
+   * @param {Function} factory Executed immediately receiving the convo instance as it's only param.
+   */
   conversation(factory) {
     return this.bot.conversation(this.userId, factory);
   }

--- a/lib/Conversation.js
+++ b/lib/Conversation.js
@@ -1,8 +1,14 @@
 'use strict';
 const Chat = require('./Chat');
 const textMatchesPatterns = require('./utils/text-matches-patterns');
+const BootBot = require('./BootBot');
 
 class Conversation extends Chat {
+  /**
+   * Create a new conversation with a user.
+   * @param {BootBot} bot Bot instance
+   * @param {String} userId 
+   */
   constructor(bot, userId) {
     super(bot, userId);
     this.bot = bot;
@@ -12,6 +18,21 @@ class Conversation extends Chat {
     this.start();
   }
 
+   /**
+   * @typedef {Object} SendMessageOptions
+   * @property {Boolean|Number} [typing=false] Send a typing indicator before sending the message. If set to true, it will automatically calculate how long it lasts based on the message length. If it's a number, it will show the typing indicator for that amount of milliseconds (max. 20000 - 20 seconds)
+   * @property {Function} [onDelivery] Callback that will be executed when the message is received by the user. Receives params: (payload, chat, data)
+   * @property {Function} [onRead] Callback that will be executed when the message is read by the user. Receives params: (payload, chat, data)
+   */
+
+  /**
+   * If question is a string or an object, the .say() method will be invoked immediately with that string or object, if it's a function it will also be invoked immedately with the convo instance as its only param.
+   * @param {String} question 
+   * @param {Function} answer Receives the payload, convo and data params (similar to the callback function of the .on() or .hear() methods, except it receives the convo instance instead of the chat instance). The answer function will be called whenever the user replies to the question with a text message or quick reply.
+   * @param {Array.<Function>} callbacks Used to listen to specific types of answers to the question. You can listen for postback, quick_reply and attachment events, or you can match a specific text pattern.
+   * @param {SendMessageOptions} options 
+   * @returns {this}
+   */
   ask(question, answer, callbacks, options) {
     if (!question || !answer || typeof answer !== 'function') {
       return console.error(`You need to specify a question and answer to ask`);
@@ -27,6 +48,10 @@ class Conversation extends Chat {
     return this;
   }
 
+  /**
+   * @param {Object} payload 
+   * @param {Object} data 
+   */
   respond(payload, data) {
     if (!this.isWaitingForAnswer()) {
       // If the conversation has been started but no question has been asked yet,
@@ -132,16 +157,28 @@ class Conversation extends Chat {
     return this;
   }
 
+  /**
+   * Ends a conversation, giving control back to the bot instance. All .on() and .hear() listeners are now back in action. After you end a conversation the values that you saved using the convo.set() method are now lost.
+   */
   end() {
     this.active = false;
     this.emit('end', this);
     return this;
   }
 
+  /**
+   * Retrieve a value from the conversation's context
+   * @param {String} property 
+   */
   get(property) {
     return this.context[property];
   }
 
+  /**
+   * Save a value in the conversation's context. This value will be available in all subsequent questions and answers that are part of this conversation, but the values are lost once the conversation ends.
+   * @param {String} property
+   * @param {*} value
+   */
   set(property, value) {
     this.context[property] = value;
     return this.context[property];

--- a/lib/utils/normalize-string.js
+++ b/lib/utils/normalize-string.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @param {String} str
+ * @returns {String}
+ */
 module.exports = (str) => (
   str.replace(/[^a-zA-Z0-9]+/g, '').toUpperCase()
 );

--- a/lib/utils/text-matches-patterns.js
+++ b/lib/utils/text-matches-patterns.js
@@ -1,4 +1,9 @@
 'use strict';
+
+/**
+ * @param {String} text 
+ * @param {Array.<String>|String} patterns
+ */
 module.exports = (text, patterns) => {
   const keywords = Array.isArray(patterns) ? patterns : [ patterns ];
   for (let i = 0; i < keywords.length; i += 1) {


### PR DESCRIPTION
I added jsdoc comments for the added benefit of autocompletion. Doc strings are a combination of what is already in the readme, a bit of the Facebook docs, and some editorialised explanations of the private functions.

I personally prefer this method over what has been done in PR #114 as inline documentation is much more helpful, although #114 could benefit TypeScript users (I'm not a TS user so wouldn't want to comment).

Closes #115 