### PR TITLE
Provides opportunity to use BootBot without creating a new express server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ If you want to specify a custom endpoint name for your webhook, you can do it wi
 
 Starts the express server on the specified port. Defaults port to 3000.
 
+#### `.getRouter()`
+Returns the express router, that BootBot uses. It can be [used](https://expressjs.com/en/guide/routing.html#express-router), when you can only use one port.
+
+
+##### `.getRouter()` examples:
+
+```javascript
+app.use('/bootbot', bot.getRouter());
+
+app.listen(3000, () => console.log('BootBot and Express are listening on port 3000!'));
+```
+
 #### `.close()`
 
 Closes the express server (calls `.close()` on the server instance).

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -51,6 +51,16 @@ class BootBot extends EventEmitter {
   }
 
   /**
+   * Returns the express router, that BootBot uses.
+   * It can be used, when you can only use one port.
+   */
+  getRouter(){
+    this._initWebhook();
+    console.log('BootBot running on the same port as express');
+    return this.app;
+  }
+
+  /**
    * Closes the express server (calls `.close()` on the server instance).
    */
   close() {

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -29,6 +29,7 @@ class BootBot extends EventEmitter {
     this.appSecret = options.appSecret;
     this.broadcastEchoes = options.broadcastEchoes || false;
     this.app = express();
+    this.router = express.Router();
     this.webhook = options.webhook || '/webhook';
     this.webhook = this.webhook.charAt(0) !== '/' ? `/${this.webhook}` : this.webhook;
     this.app.use(bodyParser.json({ verify: this._verifyRequestSignature.bind(this) }));
@@ -41,7 +42,7 @@ class BootBot extends EventEmitter {
    * @param {Number} [port=3000]
    */
   start(port) {
-    this._initWebhook();
+    this._initWebhook('app');
     this.app.set('port', port || 3000);
     this.server = this.app.listen(this.app.get('port'), () => {
       const portNum = this.app.get('port');
@@ -55,9 +56,9 @@ class BootBot extends EventEmitter {
    * It can be used, when you can only use one port.
    */
   getRouter(){
-    this._initWebhook();
+    this._initWebhook('router');
     console.log('BootBot running on the same port as express');
-    return this.app;
+    return this.router;
   }
 
   /**
@@ -607,8 +608,8 @@ class BootBot extends EventEmitter {
   }
 
 
-  _initWebhook() {
-    this.app.get(this.webhook, (req, res) => {
+  _initWebhook(app='app') {
+    this[app].get(this.webhook, (req, res) => {
       if (req.query['hub.mode'] === 'subscribe' && req.query['hub.verify_token'] === this.verifyToken) {
         console.log('Validation Succeded.')
         res.status(200).send(req.query['hub.challenge']);
@@ -618,7 +619,7 @@ class BootBot extends EventEmitter {
       }
     });
 
-    this.app.post(this.webhook, (req, res) => {
+    this[app].post(this.webhook, (req, res) => {
       var data = req.body;
       if (data.object !== 'page') {
         return;


### PR DESCRIPTION
I had a problem while using ChatBot on Heroku; I couldn't run my express server and chatbot server at the same time, in the same app. This modification allows to do it. 