### PR TITLE
Fix for hardcoded content_type value in quickReplies in BootBot

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -515,7 +515,7 @@ class BootBot extends EventEmitter {
         };
       } else if (reply && reply.title) {
         return Object.assign({
-          content_type: 'text',
+          content_type: reply.content_type || 'text',
           payload: 'BOOTBOT_QR_' + normalizeString(reply.title)
         }, reply);
       }


### PR DESCRIPTION
Value for `content_type` to this moment was hardcoded. You can't use for eg `geolocation` content_type. Tests are fine but implementation was missing