### PR TITLE
Update Graph API to 2.12

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -270,7 +270,7 @@ class BootBot extends EventEmitter {
   sendRequest(body, endpoint, method) {
     endpoint = endpoint || 'messages';
     method = method || 'POST';
-    return fetch(`https://graph.facebook.com/v2.6/me/${endpoint}?access_token=${this.accessToken}`, {
+    return fetch(`https://graph.facebook.com/v2.12/me/${endpoint}?access_token=${this.accessToken}`, {
       method,
       headers: {
         'Content-Type': 'application/json'
@@ -334,7 +334,7 @@ class BootBot extends EventEmitter {
    * @returns {Promise}
    */
   getUserProfile(userId) {
-    const url = `https://graph.facebook.com/v2.6/${userId}?fields=first_name,last_name,profile_pic,locale,timezone,gender&access_token=${this.accessToken}`;
+    const url = `https://graph.facebook.com/v2.12/${userId}?fields=first_name,last_name,profile_pic,locale,timezone,gender&access_token=${this.accessToken}`;
     return fetch(url)
       .then(res => res.json())
       .catch(err => console.log(`Error getting user profile: ${err}`));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootbot",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Facebook Messenger Bot Framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello, 

Graph API v2.6 will be deprecated on Jul 13, 2018.
I've updated API to v2.12 which will be available until May 1, 2020. 

For me code is fully working.