### PR TITLE
perf: add conversations hash by userId

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -34,6 +34,7 @@ class BootBot extends EventEmitter {
     this.app.use(bodyParser.json({ verify: this._verifyRequestSignature.bind(this) }));
     this._hearMap = [];
     this._conversations = [];
+    this._conversationsByUserIdHash = {};
   }
 
   /**
@@ -473,13 +474,27 @@ class BootBot extends EventEmitter {
       return console.error(`You need to specify a recipient and a callback to start a conversation`);
     }
     const convo = new Conversation(this, recipientId);
-    this._conversations.push(convo);
-    convo.on('end', (endedConvo) => {
-      const removeIndex = this._conversations.indexOf(endedConvo);
-      this._conversations.splice(removeIndex, 1);
-    });
+
+    this._addConversation(convo);
+
     factory.apply(this, [convo]);
     return convo;
+  }
+
+  /**
+   * Used to add Conversation instance with maintaining appropriate hash by userId.
+   * @param {Conversation} conversation will be added to the instance's conversations list.
+   */
+  _addConversation(convo) {
+    const userId = convo.userId;
+
+    this._conversationsByUserIdHash[userId] = convo;
+    this._conversations.push(convo);
+
+    convo.on('end', (endedConvo) => {
+      this._conversations.splice(this._conversations.indexOf(endedConvo), 1);
+      delete this._conversationsByUserIdHash[endedConvo.userId];
+    });
   }
 
   /**
@@ -588,14 +603,16 @@ class BootBot extends EventEmitter {
 
   _handleConversationResponse(type, event) {
     const userId = event.sender.id;
-    let captured = false;
-    this._conversations.forEach(convo => {
-      if (userId && userId === convo.userId && convo.isActive()) {
-        captured = true;
-        return convo.respond(event, { type });
-      }
-    });
-    return captured;
+
+    const convo = this._conversationsByUserIdHash[userId];
+
+    if (!convo || !convo.isActive()) {
+      return false;
+    }
+
+    convo.respond(event, { type });
+
+    return true;
   }
 
   /**


### PR DESCRIPTION
in order to access a required conversation instance in a more performant way

Closes: https://github.com/Charca/bootbot/issues/155