### PR TITLE
Fix/Issue 159: Fix exceptions being swallowed by BootBot

### DIFF
--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -285,7 +285,11 @@ class BootBot extends EventEmitter {
       }
       return res;
     })
-    .catch(err => console.log(`Error sending message: ${err}`));
+    .catch(err => {
+      console.log(`Error sending message: ${err}`);
+
+      throw err;
+    });
   }
 
   /**
@@ -337,7 +341,11 @@ class BootBot extends EventEmitter {
     const url = `https://graph.facebook.com/v2.12/${userId}?fields=first_name,last_name,profile_pic,locale,timezone,gender&access_token=${this.accessToken}`;
     return fetch(url)
       .then(res => res.json())
-      .catch(err => console.log(`Error getting user profile: ${err}`));
+      .catch(err => {
+        console.log(`Error getting user profile: ${err}`);
+
+        throw err;
+      });
   }
 
   /**


### PR DESCRIPTION
`throw` errors from within `sendRequest` and `getUserProfile` functions.