### PR TITLE
Enchantment: Add Graph API version option to BootBot constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Then use the provided HTTPS URL to config your webhook on Facebook's Dashboard. 
 | `appSecret` | string | | `Y` |
 | `webhook` | string | `"/webhook"` | `N` |
 | `broadcastEchoes` | boolean | `false` | `N` |
+| `graphApiVersion` | string | `v2.12` | `N` |
 
 Creates a new `BootBot` instance. Instantiates the new express app and all required webhooks. `options` param must contain all tokens and app secret of your Facebook app. Optionally, set `broadcastEchoes` to `true` if you want the messages your bot send to be echoed back to it (you probably don't need this feature unless you have multiple bots running on the same Facebook page).
 

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -18,6 +18,7 @@ class BootBot extends EventEmitter {
    * @param {String} options.appSecret
    * @param {String} [options.webhook=/webhook]
    * @param {Boolean} [options.broadcastEchoes=false]
+   * @param {String} [options.graphApiVersion=v2.12]
    */
   constructor(options) {
     super();
@@ -28,6 +29,7 @@ class BootBot extends EventEmitter {
     this.verifyToken = options.verifyToken;
     this.appSecret = options.appSecret;
     this.broadcastEchoes = options.broadcastEchoes || false;
+    this.graphApiVersion = options.graphApiVersion || 'v2.12';
     this.app = express();
     this.webhook = options.webhook || '/webhook';
     this.webhook = this.webhook.charAt(0) !== '/' ? `/${this.webhook}` : this.webhook;
@@ -270,7 +272,7 @@ class BootBot extends EventEmitter {
   sendRequest(body, endpoint, method) {
     endpoint = endpoint || 'messages';
     method = method || 'POST';
-    return fetch(`https://graph.facebook.com/v2.12/me/${endpoint}?access_token=${this.accessToken}`, {
+    return fetch(`https://graph.facebook.com/${this.graphApiVersion}/me/${endpoint}?access_token=${this.accessToken}`, {
       method,
       headers: {
         'Content-Type': 'application/json'
@@ -334,7 +336,7 @@ class BootBot extends EventEmitter {
    * @returns {Promise}
    */
   getUserProfile(userId) {
-    const url = `https://graph.facebook.com/v2.12/${userId}?fields=first_name,last_name,profile_pic,locale,timezone,gender&access_token=${this.accessToken}`;
+    const url = `https://graph.facebook.com/${this.graphApiVersion}/${userId}?fields=first_name,last_name,profile_pic,locale,timezone,gender&access_token=${this.accessToken}`;
     return fetch(url)
       .then(res => res.json())
       .catch(err => console.log(`Error getting user profile: ${err}`));


### PR DESCRIPTION
The API version is set to `v2.12` by default.
And it is up to user to input the correct Graph API version.