### PR TITLE
getUserProfile() default fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,9 +530,13 @@ You can also use this method via the `typing` option (see [`.say()`](#say) metho
 
 | Method signature |
 |:-----------------|
-| `chat.getUserProfile()` |
-| `convo.getUserProfile()` |
-| `bot.getUserProfile(userId)` |
+| `chat.getUserProfile(fields)` |
+| `convo.getUserProfile(fields)` |
+| `bot.getUserProfile(userId, fields)` |
+
+| Param | Type | Default | Required |
+|:------|:-----|:--------|:---------|
+| `fields` | array | ['id', 'name', 'first_name', 'last_name', 'profile_pic']  | `N` |
 
 This method is not technically part of the "Send" API, but it's listed here because it's also shared between the `bot`, `chat` and `convo` instances.
 
@@ -543,6 +547,16 @@ bot.hear('hello', (payload, chat) => {
   chat.getUserProfile().then((user) => {
     chat.say(`Hello, ${user.first_name}!`);
   });
+
+  // or
+
+  const fields = ['locale', 'timezone', 'gender']; // change permissions
+
+  chat.getUserProfile(fields).then((user) => {
+      chat.say(`Hello, ${user.first_name}!`);
+      chat.say(`Your locale, ${user.locale}!`);
+  });
+
 });
 ```
 

--- a/examples/user-profile-example.js
+++ b/examples/user-profile-example.js
@@ -12,9 +12,15 @@ const bot = new BootBot({
 bot.module(echoModule);
 
 bot.hear('hello', (payload, chat) => {
-  chat.getUserProfile().then((user) => {
+  const fields = ['locale', 'timezone', 'gender']; // change permissions
+  chat.getUserProfile(fields).then((user) => {
     chat.say(`Hello, ${user.first_name}!`);
   });
+
+  // or don't pass variable "fields"
+  /* chat.getUserProfile().then((user) => {
+    chat.say(`Hello, ${user.first_name}!`);
+  }); */
 });
 
 bot.start();

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -333,10 +333,16 @@ class BootBot extends EventEmitter {
   /**
    * Returns a Promise that contains the user's profile information.
    * @param {String} userId
+   * @param {Array} fields Additions fields (ex.: locale/timezone/gender).
    * @returns {Promise}
    */
-  getUserProfile(userId) {
-    const url = `https://graph.facebook.com/${this.graphApiVersion}/${userId}?fields=first_name,last_name,profile_pic,locale,timezone,gender&access_token=${this.accessToken}`;
+  getUserProfile(userId, fields) {
+    const defaultFields = ['id', 'name', 'first_name', 'last_name', 'profile_pic'];
+    if (!Array.isArray(fields)) {
+      throw new Error('Fields is supposed to be an array');
+    } else Array.prototype.push.apply(defaultFields, fields.map(field => field.trim()));
+    const mergeFields = defaultFields.reduce((url, elem) => `${url},${elem}`);
+    const url = `https://graph.facebook.com/${this.graphApiVersion}/${userId}?fields=${mergeFields}&access_token=${this.accessToken}`;
     return fetch(url)
       .then(res => res.json())
       .catch(err => console.log(`Error getting user profile: ${err}`));

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -332,6 +332,9 @@ class BootBot extends EventEmitter {
 
   /**
    * Returns a Promise that contains the user's profile information.
+   * Default fields: id, name, first_name, last_name, profile_pic
+   * Additional fields: locale, timezone, gender
+   * Link: https://developers.facebook.com/docs/messenger-platform/identity/user-profile
    * @param {String} userId
    * @param {Array} fields Additions fields (ex.: locale/timezone/gender).
    * @returns {Promise}

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -344,7 +344,7 @@ class BootBot extends EventEmitter {
     if (!Array.isArray(fields)) {
       throw new Error('Fields is supposed to be an array');
     } else Array.prototype.push.apply(defaultFields, fields.map(field => field.trim()));
-    const mergeFields = defaultFields.reduce((url, elem) => `${url},${elem}`);
+    const mergeFields = defaultFields.join(',');
     const url = `https://graph.facebook.com/${this.graphApiVersion}/${userId}?fields=${mergeFields}&access_token=${this.accessToken}`;
     return fetch(url)
       .then(res => res.json())

--- a/lib/Chat.js
+++ b/lib/Chat.js
@@ -158,9 +158,11 @@ class Chat extends EventEmitter {
 
   /**
    * Returns a Promise that contains the user's profile information.
+   * @param {Array} fields
+   * @returns {Promise}
    */
-  getUserProfile() {
-    return this.bot.getUserProfile(this.userId);
+  getUserProfile(fields) {
+    return this.bot.getUserProfile(this.userId, fields);
   }
 
   /**


### PR DESCRIPTION
_Hello!_ ✌️

Permissions my application ("locale", "timezone", "gender" unavailable):

<img width="990" alt="2019-01-17 11 21 21" src="https://user-images.githubusercontent.com/41549580/51304765-1264aa80-1a4a-11e9-8850-63e3183f2881.png">

Next, we downloaded current version package (1.0.16), used method "getUserProfile()" and get the follow error 😑:

```json
{  
   "error":{  
      "message":"(#100) Insufficient permission to access user profile.",
      "type":"OAuthException",
      "code":100,
      "error_subcode":2018247,
      "fbtrace_id":"CZW1EcCa704"
   }
}
```

Changed method "getUserProfile()":

```javascript
getUserProfile(userId, fields) {
    const defaultFields = ['id', 'name', 'first_name', 'last_name', 'profile_pic'];
    if (!Array.isArray(fields)) {
      throw new Error('Fields is supposed to be an array');
    } else Array.prototype.push.apply(defaultFields, fields.map(field => field.trim()));
    const mergeFields = defaultFields.join(',');
    const url = `https://graph.facebook.com/${this.graphApiVersion}/${userId}?fields=${mergeFields}&access_token=${this.accessToken}`;
    return fetch(url)
      .then(res => res.json())
      .catch(err => console.log(`Error getting user profile: ${err}`));
  }
```

Thanks!
