### PR TITLE
HTTPS server feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ BootBot is a simple but powerful JavaScript Framework to build Facebook Messenge
 $ npm install bootbot --save
 ```
 
+For a usage with a proxy (without HTTPS)
+
 ```javascript
 'use strict';
 const BootBot = require('bootbot');
@@ -42,6 +44,32 @@ bot.on('message', (payload, chat) => {
 });
 
 bot.start();
+```
+
+For a usage with a HTTPS credidential
+
+```javascript
+'use strict';
+const BootBot = require('bootbot');
+
+const bot = new BootBot({
+  accessToken: 'FB_ACCESS_TOKEN',
+  verifyToken: 'FB_VERIFY_TOKEN',
+  appSecret: 'FB_APP_SECRET'
+});
+
+bot.on('message', (payload, chat) => {
+  const text = payload.message.text;
+  chat.say(`Echo: ${text}`);
+});
+
+const privateKey  = fs.readFileSync('key.pem', 'utf8');
+const certificate = fs.readFileSync('certchain.pem', 'utf8');
+
+const credentials = {key: privateKey, cert: certificate};
+
+// 3000 for the port, you can use undefined for the default port
+bot.start(3000, credentials);
 ```
 
 ## Video Example
@@ -154,10 +182,22 @@ bot.hear('ask me something', (payload, chat) => {
 });
 ```
 
-- Set up webhooks and start the express server:
+- Set up webhooks and start the express/HTTPS server:
 
+express
 ```javascript
 bot.start();
+```
+
+HTTPS
+```javascript
+const privateKey  = fs.readFileSync('key.pem', 'utf8');
+const certificate = fs.readFileSync('certchain.pem', 'utf8');
+
+const credentials = {key: privateKey, cert: certificate};
+
+// 3000 for the port, you can use undefined for the default port
+bot.start(3000, credentials);
 ```
 
 - Start up your bot by running node:

--- a/lib/BootBot.js
+++ b/lib/BootBot.js
@@ -36,27 +36,46 @@ class BootBot extends EventEmitter {
     this.app.use(this.webhook, bodyParser.json({ verify: this._verifyRequestSignature.bind(this) }));
     this._hearMap = [];
     this._conversations = [];
+    this.httpsServer = undefined;
   }
 
   /**
-   * Starts the express server on the specified port. Defaults port to 3000.
+   * Starts the express or HTTPS server on the specified port. Defaults port to 3000.
    * @param {Number} [port=3000]
+   * @param {{ key: string, cert: string }} [credentials=undefined] The credentials needed to run the https server
    */
-  start(port) {
+  start(port, credentials) {
     this._initWebhook();
     this.app.set('port', port || 3000);
-    this.server = this.app.listen(this.app.get('port'), () => {
-      const portNum = this.app.get('port');
-      console.log('BootBot running on port', portNum);
-      console.log(`Facebook Webhook running on localhost:${portNum}${this.webhook}`);
-    });
+    if (credentials) {
+      // Start the HTTPS server
+      this.httpsServer = https.createServer(credentials, this.app);
+      this.httpsServer.listen(this.app.get('port'), () => {
+        const portNum = this.app.get('port');
+        console.log(`BootBot running with SSL/TLS on port ${portNum}`);
+        console.log(`Facebook Webhook running with SSL/TLS on localhost:${portNum}${this.webhook}`);
+      });
+    } else {
+      // Start the express server
+      this.server = this.app.listen(this.app.get('port'), () => {
+        const portNum = this.app.get('port');
+        console.log(`BootBot running without SSL/TLS on port ${portNum}`);
+        console.log(`Facebook Webhook running without SSL/TLS on localhost:${portNum}${this.webhook}`);
+      });
+    }
   }
 
   /**
-   * Closes the express server (calls `.close()` on the server instance).
+   * Closes the express or HTTPS server (calls `.close()` on the server instance).
    */
   close() {
-    this.server.close();
+    if (this.httpsServer) {
+      // Close the https server
+      this.httpsServer.close();
+    } else {
+      // Close the express server
+      this.server.close();
+    }
   }
 
   /**


### PR DESCRIPTION
# HTTPS server feature

The pull request from the issue #182 

You can now start a HTTPS server with credentials

```javascript
const port = 3000;

const privateKey = fs.readFileSync(env_1.config.tls.key, 'utf8');
const certificate = fs.readFileSync(env_1.config.tls.cert, 'utf8');
const credentials = { key: privateKey, cert: certificate };

new BootBot(...).start(port, credentials);
```